### PR TITLE
Add ability to hide secondary_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Inspired by [mini media player](https://github.com/kalkih/mini-media-player).
 | **secondary_info** | object | optional | v2.1.1 | secondary_info config. [secondary info examples](#secondary-info)
 | secondary_info: `type` | string | optional | v2.1.1 | available types: `last-changed, mode`
 | secondary_info: `icon` | string | optional | v2.1.1 | icon for type: `mode`
+| secondary_info: `hide` | boolean | optional | v2.2.5 | Hide secondary info, default `False`
 | **power** | object | optional | v2.0.1 | Power button, [example](#power-button).
 | power: `type` | string | optional | v2.0.1 | `toggle` or `button`, default `button`
 | power: `icon` | string | optional | v2.0.1 | Specify a custom icon from any of the available mdi icons, default `mdi:power`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-humidifier",
-  "version": "v2.2.4",
+  "version": "v2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -514,6 +514,10 @@ class MiniHumidifier extends LitElement {
     if (this.humidifier.isUnavailable)
       return '';
 
+    if (this.config.secondary_info.hide) {
+      return '';
+    }
+
     if (this.config.secondary_info.type === 'last-changed') {
       return html`
       <div class='entity__secondary_info ellipsis'>

--- a/src/style.js
+++ b/src/style.js
@@ -166,6 +166,9 @@ const style = css`
     margin-top: calc(var(--mh-unit) * .075);
   }
   .entity__info__name_wrap {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
     margin-right: 0;
     max-width: calc(var(--mh-unit) * 4.25);
     cursor: pointer;


### PR DESCRIPTION
Thanks for the card!

I've added the ability to hide `secondary_info`. Here's how it look for me locally:

<img width="500" alt="Screenshot 2020-10-23 at 00 01 38" src="https://user-images.githubusercontent.com/3459374/96929529-edc12080-14c2-11eb-8d8f-f3d78ba6b83d.png">