### PR TITLE
Add default config for xiaomi_miio:zhimi_humidifier_ca4

### DIFF
--- a/src/configurations/xiaomi_miio/zhimi_humidifier_ca4.js
+++ b/src/configurations/xiaomi_miio/zhimi_humidifier_ca4.js
@@ -1,0 +1,131 @@
+import { ICON } from '../../const';
+
+const ZHIMI_HUMIDIFIER_CA4 = () => ({
+  power: {
+    icon: ICON.POWER,
+    type: 'button',
+    hide: false,
+    toggle_action: (state, entity) => {
+      const service = state === 'on' ? 'turn_off' : 'turn_on';
+      const options = { entity_id: entity.entity_id };
+      return this.call_service('fan', service, options);
+    },
+  },
+  target_humidity: {
+    icon: ICON.HUMIDITY,
+    unit: '%',
+    min: 30,
+    max: 80,
+    step: 10,
+    hide: false,
+    hide_indicator: false,
+    state: { attribute: 'target_humidity' },
+    change_action: (selected, state, entity) => {
+      const options = { entity_id: entity.entity_id, humidity: selected };
+      return this.call_service('xiaomi_miio', 'fan_set_target_humidity', options);
+    },
+  },
+  indicators: {
+    depth: {
+      icon: ICON.DEPTH,
+      unit: '%',
+      round: 0,
+      order: 0,
+      hide: false,
+      source: { attribute: 'water_level' },
+    },
+    temperature: {
+      icon: ICON.TEMPERATURE,
+      unit: '°C',
+      round: 1,
+      order: 1,
+      hide: false,
+      source: { attribute: 'temperature' },
+    },
+    humidity: {
+      icon: ICON.HUMIDITY,
+      unit: '%',
+      round: 1,
+      order: 2,
+      hide: false,
+      source: { attribute: 'humidity' },
+    },
+    motor_speed: {
+      icon: ICON.RPM,
+      unit: 'rpm',
+      round: 0,
+      order: 3,
+      hide: false,
+      source: { attribute: 'motor_speed' },
+    },
+  },
+  buttons: {
+    dry: {
+      icon: ICON.DRY,
+      hide: false,
+      order: 0,
+      state: { attribute: 'dry', mapper: state => (state ? 'on' : 'off') },
+      toggle_action: (state, entity) => {
+        const service = state === 'on' ? 'fan_set_dry_off' : 'fan_set_dry_on';
+        const options = { entity_id: entity.entity_id };
+        return this.call_service('xiaomi_miio', service, options);
+      },
+    },
+    mode: {
+      icon: ICON.FAN,
+      type: 'dropdown',
+      hide: false,
+      order: 1,
+      source: {
+        auto: 'auto',
+        low: 'low',
+        medium: 'medium',
+        high: 'high',
+      },
+      active: (state, entity) => (entity.state !== 'off'),
+      disabled: (state, entity) => (entity.attributes.depth === 0),
+      state: { attribute: 'mode', mapper: state => (['auto', 'low', 'medium', 'high'][state]) },
+      change_action: (selected, state, entity) => {
+        const options = { entity_id: entity.entity_id, speed: selected };
+        return this.call_service('fan', 'set_speed', options);
+      },
+    },
+    led: {
+      icon: ICON.LEDBUTTON,
+      type: 'dropdown',
+      hide: false,
+      order: 2,
+      active: state => (state !== 0 && state !== '0'),
+      source: { 0: 'Off', 1: 'Dim', 2: 'Bright' },
+      state: { attribute: 'led_brightness' },
+      change_action: (selected, state, entity) => {
+        const options = { entity_id: entity.entity_id, brightness: selected };
+        return this.call_service('xiaomi_miio', 'fan_set_led_brightness', options);
+      },
+    },
+    buzzer: {
+      icon: ICON.BUZZER,
+      hide: false,
+      order: 3,
+      state: { attribute: 'buzzer', mapper: state => (state ? 'on' : 'off') },
+      toggle_action: (state, entity) => {
+        const service = state === 'on' ? 'fan_set_buzzer_off' : 'fan_set_buzzer_on';
+        const options = { entity_id: entity.entity_id };
+        return this.call_service('xiaomi_miio', service, options);
+      },
+    },
+    child_lock: {
+      icon: ICON.CHILDLOCK,
+      hide: false,
+      order: 4,
+      state: { attribute: 'child_lock', mapper: state => (state ? 'on' : 'off') },
+      toggle_action: (state, entity) => {
+        const service = state === 'on' ? 'fan_set_child_lock_off' : 'fan_set_child_lock_on';
+        const options = { entity_id: entity.entity_id };
+        return this.call_service('xiaomi_miio', service, options);
+      },
+    },
+  },
+});
+
+export default ZHIMI_HUMIDIFIER_CA4;

--- a/src/humidifiers.js
+++ b/src/humidifiers.js
@@ -1,4 +1,5 @@
 import ZHIMI_HUMIDIFIER_CB1 from './configurations/xiaomi_miio/zhimi_humidifier_cb1';
+import ZHIMI_HUMIDIFIER_CA4 from './configurations/xiaomi_miio/zhimi_humidifier_ca4';
 import ZHIMI_AIRPURIFIER_MA2 from './configurations/xiaomi_miio/zhimi_airpurifier_ma2';
 import XIAOMI_MIIO_AIRPURIFIER_DEERMA_HUMIDIFIER_MJJSQ from './configurations/xiaomi_miio_airpurifier/deerma_humidifier_mjjsq';
 import XIAOMI_MIIO_AIRPURIFIER_ZHIMI_HUMIDIFIER_CB1 from './configurations/xiaomi_miio_airpurifier/zhimi_humidifier_cb1';
@@ -8,6 +9,7 @@ const HUMIDIFIERS = {
   default: ZHIMI_HUMIDIFIER_CB1,
   // xiaomi_miio integration (default home assistant)
   'zhimi.humidifier.cb1': ZHIMI_HUMIDIFIER_CB1,
+  'zhimi.humidifier.ca4': ZHIMI_HUMIDIFIER_CA4,
   'zhimi.airpurifier.ma2': ZHIMI_AIRPURIFIER_MA2,
 
   // xiaomi_miio_airpurifier integration https://github.com/syssi/xiaomi_airpurifier


### PR DESCRIPTION
Hi!

@artem-sedykh Thanks for work!

Just added the default config for built in integration xiaomi_miio for zhimi_humidifier_ca4.

To support automatic speed mode need some patches to home-assistant/core and python-miio: https://github.com/home-assistant/core/issues/44292#issuecomment-762390338 (near future).