### PR TITLE
[fix] zhimi_humidifier_ca4: preset_mode

### DIFF
--- a/src/configurations/xiaomi_miio_airpurifier/zhimi_humidifier_ca4.js
+++ b/src/configurations/xiaomi_miio_airpurifier/zhimi_humidifier_ca4.js
@@ -86,8 +86,8 @@ const XIAOMI_MIIO_AIRPURIFIER_ZHIMI_HUMIDIFIER_CA4 = () => ({
       disabled: (state, entity) => (entity.attributes.depth === 0),
       state: { attribute: 'mode' },
       change_action: (selected, state, entity) => {
-        const options = { entity_id: entity.entity_id, speed: selected };
-        return this.call_service('fan', 'set_speed', options);
+        const options = { entity_id: entity.entity_id, preset_mode: selected };
+        return this.call_service('fan', 'set_preset_mode', options);
       },
     },
     led: {


### PR DESCRIPTION
New version of xiaomi_miio_airpurifier integration use 'preset_mode' instead 'speed'.
In this commit fixed it.